### PR TITLE
Update pubsub-dapr-csharp-servicebus README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,9 @@ dapr stop --app-id order-processor
 NOTE: make sure you have Azure Dev CLI pre-reqs [here](https://github.com/Azure-Samples/todo-python-mongo-aca)
 
 ```bash
+azd init
+```
+
+```bash
 azd up
 ```

--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ dapr stop --app-id order-processor
 
 NOTE: make sure you have Azure Dev CLI pre-reqs [here](https://github.com/Azure-Samples/todo-python-mongo-aca)
 
-5. Open a terminal, create a new empty folder, and change into it.
-6. Run the following command to initialize the project. 
+5. Run the following command to initialize the project. 
 
 ```bash
 azd init --template https://github.com/Azure-Samples/pubsub-dapr-csharp-servicebus
@@ -122,7 +121,7 @@ This command will clone the code to your current folder and prompt you for the f
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
 
-7. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+6. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
 
 ```bash
 azd up

--- a/README.md
+++ b/README.md
@@ -107,14 +107,29 @@ dapr stop --app-id order-processor
 
 ### Deploy apps to Azure (Azure Container Apps, Azure Service Bus)
 
-5. Deploy to Azure for dev-test
+#### Deploy to Azure for dev-test
 
 NOTE: make sure you have Azure Dev CLI pre-reqs [here](https://github.com/Azure-Samples/todo-python-mongo-aca)
 
+5. Open a terminal, create a new empty folder, and change into it.
+6. Run the following command to initialize the project. 
+
 ```bash
-azd init
-```
+azd init --template https://github.com/Azure-Samples/pubsub-dapr-csharp-servicebus
+``` 
+
+This command will clone the code to your current folder and prompt you for the following information:
+
+- `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
+
+7. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
 
 ```bash
 azd up
 ```
+
+This command will prompt you for the following information:
+- `Azure Location`: The Azure location where your resources will be deployed.
+- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
+
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This command will clone the code to your current folder and prompt you for the f
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
 
-6. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+6. Run the following command to package a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the application code to those newly provisioned resources.
 
 ```bash
 azd up
@@ -131,4 +131,4 @@ This command will prompt you for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
-> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (packages a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.


### PR DESCRIPTION
Update pubsub-dapr-csharp-servicebus README to use `azd init` and `azd up` instead of `azd up --template` according to https://github.com/Azure/azure-dev/issues/1769.

@jongio, @rajeshkamal5050 for notification.