### PR TITLE
Upgrade from .NET 6.0 to 8.0

### DIFF
--- a/checkout/Dockerfile
+++ b/checkout/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 
 # Creates a non-root user with an explicit UID and adds permission to access the /app folder
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["checkout.csproj", "./"]
 RUN dotnet restore "checkout.csproj"

--- a/checkout/checkout.csproj
+++ b/checkout/checkout.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/order-processor/Dockerfile
+++ b/order-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 7001
 
@@ -9,7 +9,7 @@ ENV ASPNETCORE_URLS=http://+:7001
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["order-processor.csproj", "./"]
 RUN dotnet restore "order-processor.csproj"

--- a/order-processor/order-processor.csproj
+++ b/order-processor/order-processor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This PR upgrades the target frameworks to .NET 8.0.

When you follow the steps in this repo's [read-me file](https://github.com/Azure-Samples/pubsub-dapr-csharp-servicebus/blob/main/README.md), warning messages appear when you build the **checkout** and **order-processor** projects, because these projects use a target framework of .NET 6.0, which has [reached the end of life and is no longer supported](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).

To eliminate the warnings, this PR upgrades the target frameworks to .NET 8.0.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe: Framework migration
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/pubsub-dapr-csharp-servicebus
cd pubsub-dapr-csharp-servicebus
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd checkout
dotnet build
cd ..
cd order-processor
dotnet build
```

## What to Check
Verify that the following warning doesn't appear after you run each `dotnet build` command:

`warning NETSDK1138: The target framework 'net6.0' is out of support and will not receive security updates in the future.`


## Other Information
<!-- Add any other helpful information that may be needed here. -->